### PR TITLE
Anpassung an bisherigen Sprachgebrauch und Korrektur der Rechtschreibfehler

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ Es folgen zwei Tabellen mit Vorschlägen für den täglichen Gebrauch.
 | merge       | mergen             | vereinigen            |
 | stash       | stashen            | bunkern               |
 | tag         | tagen              | markieren             |
-| cherry-pick | cherry-picken      | rosinen herauspicken  |
+| cherry-pick | cherry-picken      | Rosinen herauspicken  |
 
 | Substantiv   | Aktueller Gebrauch | Vorschlag        |
 |--------------|--------------------|------------------|
-| git          | git                | Schwachkopf      |
-| github       | github             | Schwachkopftreff |
+| git          | git                | Depp             |
+| github       | github             | Deppendrehkreuz  |
 | repository   | repo               | Lagerstätte      |
 | branch       | branch             | Zweig            |
 | commit       | commit             | Übergabe         |
@@ -37,7 +37,7 @@ Es folgen zwei Tabellen mit Vorschlägen für den täglichen Gebrauch.
 
 ## Beispiele
 
-    - Kannst du den Zweig, den ich gerade umgeschrieben hab, ziehen und zum Schwachkopftreff drücken?
+    - Kannst du den Zweig, den ich gerade umgeschrieben hab, ziehen und zum Deppendrehkreuz drücken?
 
     - Ich hab gerade abgezweigt und die Änderungen aus meinem Bunker übergeben.
 
@@ -62,4 +62,4 @@ vor:
     git config --global alias.bunkere stash
     git config --global alias.markiere tag
 
-    alias schwachkopf=git
+    alias depp=git

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Die tägliche Kommunikation in deutschen Entwicklungsteams, die `git`
 _"Kannst du bitte pullen"_ oder _"Hast du gepusht"_ sind nur zwei
 der oft seltsam klingenden Konstruktionen.
 
-Git auf deutsch schafft Abhilfe!
+Git auf Deutsch schafft Abhilfe!
 
 ## Vorschläge
 
@@ -26,14 +26,14 @@ Es folgen zwei Tabellen mit Vorschlägen für den täglichen Gebrauch.
 
 | Substantiv   | Aktueller Gebrauch | Vorschlag        |
 |--------------|--------------------|------------------|
-| git          | git                | schwachkopf      |
-| github       | github             | schwachkopftreff |
-| repository   | repo               | lagerstätte      |
-| branch       | branch             | zweig            |
-| commit       | commit             | übergabe         |
-| pull request | pull request       | ziehbegehren     |
-| stash        | stash              | bunker           |
-| tag          | tag                | markierung       |
+| git          | git                | Schwachkopf      |
+| github       | github             | Schwachkopftreff |
+| repository   | repo               | Lagerstätte      |
+| branch       | branch             | Zweig            |
+| commit       | commit             | Übergabe         |
+| pull request | pull request       | Ziehbegehren     |
+| stash        | stash              | Bunker           |
+| tag          | tag                | Markierung       |
 
 ## Beispiele
 
@@ -49,7 +49,7 @@ Es folgen zwei Tabellen mit Vorschlägen für den täglichen Gebrauch.
 
 Wer den nächsten Schritt machen will, hier eine Anleitung, die Git auf Deutsch
 in Deine Konsole bringt. Da Git keine Umlaute zulässt, müssen wir in den 
-Befehlen leider darauf verzichten. Nimm folgende Änderungen in Deiner `~/.gitconfig` 
+Befehlen leider darauf verzichten. Nimm folgende Änderungen in deiner `~/.gitconfig`
 vor:
 
     git config --global alias.zieh pull


### PR DESCRIPTION
Hallo liebe Freunde des gemeinsamen deutschsprachigen Programmierens,

ich habe zwei Übergaben beigelegt, die die gar schrecklichen Rechtschreibfehler beheben, sowie 'github' korrekt mit 'Deppendrehkreuz' übersetzen.

Hier der Nachweis dafür, dass das schon immer so gehandhabt wurde:

- [Suche nach "Schwachkopftreff"](https://github.com/search?l=&q=schwachkopftreff&ref=advsearch&type=Code&utf8=%E2%9C%93)
- [Suche nach "Deppendrehkreuz"](https://github.com/search?l=&q=deppendrehkreuz&ref=advsearch&type=Code&utf8=%E2%9C%93)