### PR TITLE
Übersetzungen für Nutzer des Deppenlabors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Git auf Deutsch
 
 Die tägliche Kommunikation in deutschen Entwicklungsteams, die `git` 
-(übersetzt: `Schwachkopf`) anwenden, ist oft das feinste Denglish. 
+(übersetzt: `Schwachkopf` oder `Depp`) anwenden, ist oft das feinste Denglish. 
 _"Kannst du bitte pullen"_ oder _"Hast du gepusht"_ sind nur zwei
 der oft seltsam klingenden Konstruktionen.
 

--- a/README.md
+++ b/README.md
@@ -24,16 +24,18 @@ Es folgen zwei Tabellen mit Vorschlägen für den täglichen Gebrauch.
 | tag         | tagen              | markieren             |
 | cherry-pick | cherry-picken      | Rosinen herauspicken  |
 
-| Substantiv   | Aktueller Gebrauch | Vorschlag        |
-|--------------|--------------------|------------------|
-| git          | git                | Depp             |
-| github       | github             | Deppendrehkreuz  |
-| repository   | repo               | Lagerstätte      |
-| branch       | branch             | Zweig            |
-| commit       | commit             | Übergabe         |
-| pull request | pull request       | Ziehbegehren     |
-| stash        | stash              | Bunker           |
-| tag          | tag                | Markierung       |
+| Substantiv    | Aktueller Gebrauch | Vorschlag            |
+|---------------|--------------------|----------------------|
+| git           | git                | Depp                 |
+| github        | github             | Deppendrehkreuz      |
+| gitlab        | gitlab             | Deppenlabor          |
+| repository    | repo               | Lagerstätte          |
+| branch        | branch             | Zweig                |
+| commit        | commit             | Übergabe             |
+| pull request  | pull request       | Ziehbegehren         |
+| merge request | merge request      | Vereinigungsbegehren |
+| stash         | stash              | Bunker               |
+| tag           | tag                | Markierung           |
 
 ## Beispiele
 


### PR DESCRIPTION
Nicht alle Freunde des deutschsprachigen Programmierens verwenden das Deppendrehkreuz, daher sollte auch das Deppenlabor inklusive der dortigen Vereinigungsbegehren berücksichtigt werden.