### PR TITLE
markieren -> margiern

### DIFF
--- a/README-saechsisch.md
+++ b/README-saechsisch.md
@@ -21,7 +21,7 @@ Nu folgchen zwee Tabellen mit de Vorschlechen für den tächlichen Jebrauch.
 | rebase      | rebasen            | umschreiben            |
 | merge       | mergen             | zammmeeren         |
 | stash       | stashen            | indebude             |
-| tag         | tagen              | markieren              |
+| tag         | tagen              | margiern              |
 | cherry-pick | cherry-picken      | de rosinen rausglaubm  |
 
 | Substantiv   | Aktueller jebrauch | Vorschlach     |


### PR DESCRIPTION
Es gab schon "margiern" bei den Substantiven, aber immer noch "markieren" bei den Verben. Obwohl das absichtlich gewesen sein könnte, meine ich eher dass es einfach übersehen wurde. Ich erwarte gerne Bescheid.