### PR TITLE
Die Frucht korrigieren

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Es folgen zwei Tabellen mit Vorschlägen für den täglichen Gebrauch.
 | fork        | forken             | gabeln                |
 | stash       | stashen            | bunkern               |
 | tag         | taggen             | markieren             |
-| cherry-pick | cherry-picken      | Rosinen herauspicken  |
+| cherry-pick | cherry-picken      | Kirschen herauspicken  |
 | checkout    | checkouten         | nehmen                |
 
 | Substantiv    | Aktueller Gebrauch | Vorschlag            |


### PR DESCRIPTION
"Cherry" ist natürlich eine Kirsch keine Rosine, Rosinen pickt man zwar häufiger raus, aber Ich glaub wir sollten trotzdem beim richtigen Wort bleiben. Manche picken auch die Kirschen heraus wenn sie schlecht entkernt wurden.