### PR TITLE
Aktualisieren README-saarlaendisch.md

### DIFF
--- a/README-saarlaendisch.md
+++ b/README-saarlaendisch.md
@@ -39,7 +39,7 @@ Lo kummen ewei zwo Tabelle mit Vorschläsch fia jeden Daach
 | bitbucket     | bitbucket          | Eifeltee-eemer    |
 | repository    | repo               | Laga              |
 | branch        | branch             | Aschd             |
-| commit        | commit             | Üwagab            |
+| commit        | commit             | Iwwagab           |
 | pull request  | pull request       | Zihhanfroh        |
 | merge request | merge request      | Sesammeleeanfroh  |
 | stash         | stash              | Bunga             |


### PR DESCRIPTION
Entlabialisierung (bspw. ü -> i) spricht dafür, dass das Wort mit einem kurzen I beginnt.