### PR TITLE
Korrekte Termini verwenden

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Es folgen zwei Tabellen mit Vorschlägen für den täglichen Gebrauch.
 | fork        | forken             | abspalten             |
 | stash       | stashen            | verstecken            |
 | tag         | taggen             | markieren             |
-| cherry-pick | cherry-picken      | Kirschen herauspicken |
+| cherry-pick | cherry-picken      | Rosinen herauspicken  |
 | checkout    | checkouten         | ausbuchen             |
 | squash      | squashen           | quetschen             |
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Hier noch einige (zum Teil nicht ganz ernste)
 
     - Mach ein Ziehbegehren, wenn du mit der Vereinigung fertig bist!
 
-    - Am besten wir picken uns die Kirschen aus dem Hauptzweig heraus.
+    - Am besten wir picken uns die Rosinen aus dem Hauptzweig heraus.
 
     - Gabeln Sie auf Deppendrehkreuz!
     

--- a/README.md
+++ b/README.md
@@ -21,15 +21,15 @@ Es folgen zwei Tabellen mit Vorschlägen für den täglichen Gebrauch.
 | clone       | clonen             | nachmachen            |
 | fetch       | fetchen            | holen                 |
 | branch      | branchen           | abzweigen             |
-| commit      | commiten           | festlegen             |
+| commit      | commiten           | einbuchen             |
 | rebase      | rebasen            | (neu) erden           |
 | diff        | diffen             | unterscheiden         |
 | merge       | mergen             | zusammenführen        |
 | fork        | forken             | abspalten             |
 | stash       | stashen            | verstecken            |
 | tag         | taggen             | markieren             |
-| cherry-pick | cherry-picken      | Rosinen herauspicken  |
-| checkout    | checkouten         | nehmen                |
+| cherry-pick | cherry-picken      | Kirschen herauspicken |
+| checkout    | checkouten         | ausbuchen             |
 | squash      | squashen           | quetschen             |
 
 Hier noch einige (zum Teil nicht ganz ernste)
@@ -42,9 +42,9 @@ Hier noch einige (zum Teil nicht ganz ernste)
 | gitea         | gitea              | Deppentee                  |
 | blame         | blame              | Deppenbeschuldigung        |
 | bitbucket     | bitbucket          | Gebisseimer                |
-| repository    | repo               | Lagerstätte                |
+| repository    | repo               | Depot                      |
 | branch        | branch             | Zweig                      |
-| commit        | commit             | Übergabe                   |
+| commit        | commit             | Einbuchung                 |
 | log           | log                | Tagebuch                   |
 | pull request  | pull request       | Ziehbegehren               |
 | merge request | merge request      | Antrag auf Zusammenführung |
@@ -59,7 +59,7 @@ Hier noch einige (zum Teil nicht ganz ernste)
 
     - Kannst du den Zweig, den ich gerade umgeschrieben hab, ziehen und zum Deppendrehkreuz drücken?
 
-    - Dafür habe ich eine neue Lagerstätte eröffnet, mach sie nach und nimm dir den Entwicklungszweig.
+    - Dafür habe ich ein neues Depot eröffnet, mach sie nach und nimm dir den Entwicklungszweig.
 
     - Nein, drücke das gleich zum Meister im Ursprung!
     
@@ -69,7 +69,7 @@ Hier noch einige (zum Teil nicht ganz ernste)
 
     - Mach ein Ziehbegehren, wenn du mit der Vereinigung fertig bist!
 
-    - Am besten wir picken uns die Rosinen aus dem Hauptzweig heraus.
+    - Am besten wir picken uns die Kirschen aus dem Hauptzweig heraus.
 
     - Gabeln Sie auf Deppendrehkreuz!
     
@@ -87,13 +87,13 @@ Wer den nächsten Schritt machen will, hier eine Anleitung, die Depp auf Deutsch
     git config --global alias.pfusch 'push --force'
     git config --global alias.zweig branch
     git config --global alias.verzweige branch
-    git config --global alias.uebergib commit
+    git config --global alias.buche-ein commit
     git config --global alias.erde rebase
     git config --global alias.unterscheide diff
     git config --global alias.vereinige merge
     git config --global alias.bunkere stash
     git config --global alias.markiere tag
-    git config --global alias.nimm checkout
+    git config --global alias.buche-aus checkout
     git config --global alias.tagebuch log
     git config --global alias.zustand status
     git config --global alias.beschuldige blame

--- a/deutsch.sh
+++ b/deutsch.sh
@@ -7,13 +7,13 @@ git config --local alias.drueck push
 git config --local alias.pfusch push --force-with-lease
 git config --local alias.zweig branch
 git config --local alias.verzweige branch
-git config --local alias.uebergib commit
+git config --local alias.buche-ein commit
 git config --local alias.erde rebase
 git config --local alias.unterscheide diff
 git config --local alias.vereinige merge
 git config --local alias.bunkere stash
 git config --local alias.markiere tag
-git config --local alias.nimm checkout
+git config --local alias.buche-aus checkout
 git config --local alias.tagebuch log
 git config --local alias.zustand status
 git config --local alias.beschuldige blame


### PR DESCRIPTION
Guten Tag,

es freut mich zu sehen, dass hier Wert auf ordentliche Sprache gelegt wird. Da ich dies sehr begrüße und ein paar Vorschläge meinerseits habe, habe ich mich dazu entschieden dieses Ziehbegehren von meiner Abspaltung zu eröffnen.

Das Englische Wort `repository` wird im Deutschen mit Depot übersetzt, `commit` steht für das Einbuchen der Änderungen in das Archiv des aktuellen Entwicklungszweiges.

Ich hoffe, dass Sie diese Änderungen für gut befinden und würde mich über eine Zusammenführung mit Ihrem Haupt-Entwicklungszweig freuen.

Herzliche Grüße