### PR TITLE
Schwäbisch-Schale-Manuskript hinzugefügt und LIESMICH-Dateien geändert

### DIFF
--- a/README-schwaebisch.md
+++ b/README-schwaebisch.md
@@ -13,7 +13,7 @@ Do sen zwoi Tabelle mit Vorschläg wia mer schdattdesse schwätze ko.
 | Verb        | Gschwätz grade     | Vorschlag             |
 |-------------|--------------------|-----------------------|
 | init        | initten            | uffmache              |
-| add         | adden              | drzuado               |
+| add         | adden              | drzudo                |
 | pull        | pullen             | ziage                 |
 | push        | pushen             | drigge                |
 | clone       | clonen             | kobiere               |
@@ -47,6 +47,7 @@ Do sen zwoi Tabelle mit Vorschläg wia mer schdattdesse schwätze ko.
 | tag           | tag                | Pungt                |
 | origin        | origin             | Urschbrung           |
 | master        | master             | Meischdr             |
+| main          | main               | Daez                 |
 
 ## Beischbiele
 

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ Hier noch einige (zum Teil nicht ganz ernste)
 | Substantiv    | Aktueller Gebrauch | Vorschlag                  |
 |---------------|--------------------|----------------------------|
 | git           | git                | Depp                       |
-| github        | github             | Deppendrehkreuz            |
+| github        | github             | Deppennabe                 |
 | gitlab        | gitlab             | Deppenlabor                |
 | gitea         | gitea              | Deppentee                  |
-| blame         | blame              | Deppenbeschuldigung        |
+| blame         | blame              | Beschuldigung              |
 | bitbucket     | bitbucket          | Gebisseimer                |
 | repository    | repo               | Depot                      |
 | branch        | branch             | Zweig                      |

--- a/schwaebisch.sh
+++ b/schwaebisch.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+git config --local alias.uffmache init
+git config --local alias.kobiere clone
+git config --local alias.ziage pull
+git config --local alias.drzudo add
+git config --local alias.drigge push
+git config --local alias.pfusch push --force-with-lease
+git config --local alias.abzweige branch
+git config --local alias.ibergäbe commit
+git config --local alias.schdaple rebase
+git config --local alias.ondrscheide diff
+git config --local alias.zammdoe merge
+git config --local alias.uffhebe stash
+git config --local alias.momole tag
+git config --local alias.raushole checkout
+git config --local alias.tagebuach log
+git config --local alias.zuaschtand status
+git config --local alias.beschuldige blame
+git config --local alias.bade remote
+
+echo "alias git='seggl'" >> ~/.bashrc


### PR DESCRIPTION
Ich habe ein Schalenmanuskript für schwäbisch hinzugefügt, eine Schreibweise geändert in der schwäbischen Liesmich, eine Übersetzung im Hauptliesmich korrigiert (Hub = (Rad)Nabe, Drehkreuz nur im übertragenen Sinne) und das doppelte "Depp" aus "Depp Deppenbeschuldigung" entfernt. 