### PR TITLE
Bessere übersetzung für "Github"

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Hier noch einige (zum Teil nicht ganz ernste)
 | Substantiv    | Aktueller Gebrauch | Vorschlag                  |
 |---------------|--------------------|----------------------------|
 | git           | git                | Depp                       |
-| github        | github             | Deppennabe                 |
+| github        | github             | Deppenzentrum              |
 | gitlab        | gitlab             | Deppenlabor                |
 | gitea         | gitea              | Deppentee                  |
 | blame         | blame              | Beschuldigung              |
@@ -57,7 +57,7 @@ Hier noch einige (zum Teil nicht ganz ernste)
 
 ## Beispiele
 
-    - Kannst du den Zweig, den ich gerade umgeschrieben hab, ziehen und zum Deppendrehkreuz drücken?
+    - Kannst du den Zweig, den ich gerade umgeschrieben hab, ziehen und zum Deppenzentrum drücken?
 
     - Dafür habe ich ein neues Depot eröffnet, mach sie nach und nimm dir den Entwicklungszweig.
 
@@ -71,7 +71,7 @@ Hier noch einige (zum Teil nicht ganz ernste)
 
     - Am besten wir picken uns die Rosinen aus dem Hauptzweig heraus.
 
-    - Gabeln Sie auf Deppendrehkreuz!
+    - Gabeln Sie im Deppenzentrum!
     
     - Wenn du fertig bist, dann kannst du das Ziehbegehren sofort quetschen und zusammenführen.
 


### PR DESCRIPTION
Da das `hub` in `Github` für `Zentrum` stehen soll und nichts mit Naben oder Drehkreuzen zu tun hat, habe ich es in diesem Ziehbegehren mit `Zentrum` auch ersetzt.
Klingt desweiteren auch viel unterhaltsamer.

Kann leider keine anderen Dialekte, wenn jemand Ziehbegehren für die machen würde, wäre das sehr nett.