### PR TITLE
Ziehbegehre für Git uf Thurgauerisch

### DIFF
--- a/README-thurgauerisch.md
+++ b/README-thurgauerisch.md
@@ -80,23 +80,32 @@ Da no es paar wiiteri (üsserst ernsti):
 Die wo de nächst Schritt mache wönd, chöned die Ahleitig bruche, wo de Totsch uf Thurgauerisch i ihri Konsole bringt. Will de Totsch kei Umluut zuelaht, müend mir i de einzelne Befehl leider druf verzichte. Mach die Änderige i dis `~/.gitconfig` ine:
 
     git config --global alias.ahfange init
-    git config --global alias.machnah clone
-    git config --global alias.zieh pull
     git config --global alias.tuedezue add
+    git config --global alias.beschuldig blame
+    git config --global alias.zieh pull
     git config --global alias.druck push
-    git config --global alias.pfudle 'push --force'
-    git config --global alias.zwiigli branch
+    git config --global alias.machnah clone
+    git config --global alias.hol fetch
     git config --global alias.zwiigab branch
     git config --global alias.buechiih commit
+    git config --global alias.eich rebase
+    git config --global alias.erd rebase
     git config --global alias.gahufwiifelde rebase
-    git config --global alias.unterscheide diff
+    git config --global alias.vergliich diff
     git config --global alias.tuezemme merge
     git config --global alias.versorg stash
     git config --global alias.markier tag
+    git config --global alias.pflueckoepfel cherry-pick
+    git config --global alias.pflueckhimbeeri cherry-pick
     git config --global alias.buechuus checkout
+    git config --global alias.quaetsch 'merge --squash'
+    git config --global alias.pfudle 'push --force'
+    git config --global alias.beschuldigung blame
+    git config --global alias.zwiigli branch
     git config --global alias.tagebuech log
+    git config --global alias.versteck stash
     git config --global alias.zuestand status
-    git config --global alias.beschuldige blame
+    git config --global alias.markierig tag
 
 Und wenn's die Ziile no i dis `~/.bashrc` (oder wie die Datei au immer heisst uf dim Betriebssystem) tuesch:
 

--- a/README-thurgauerisch.md
+++ b/README-thurgauerisch.md
@@ -1,0 +1,104 @@
+# Git uf Thurgauerisch
+
+S tägliche Gelaber i Programmierer-Teams, wo `git` (übersetzt: `Depp` oder `Totsch`) bruuched, isch s feinste Denglisch.
+_"Chasch du rasch pulle"_ oder _"Hesch du scho pusht"_ sind nur zwei vo de Konstruktione wo so komisch töned.
+
+Git uf Thurgauerisch hilft da!
+
+## Vorschläg
+
+Da gsehsch zwei Tabelle mit Vorschläg wo im alltäglich helfe cha.
+
+| Verb        | Jetzige Uusdruck | Vorschlag       |
+| ----------- | ---------------- | --------------- |
+| init        | initten          | ahfange         |
+| add         | adden            | dezuetue        |
+| blame       | blamen           | beschuldige     |
+| pull        | pullen           | züche           |
+| push        | pushen           | drucke          |
+| clone       | clonen           | nahmache        |
+| fetch       | fetchen          | hole            |
+| branch      | branchen         | abbüge          |
+| commit      | commiten         | iihbueche       |
+| rebase      | rebasen          | uf Wiifelde gah |
+| diff        | diffen           | vergliiche      |
+| merge       | mergen           | zemmetue        |
+| fork        | forken           | abbüge          |
+| stash       | stashen          | versorge        |
+| tag         | taggen           | markiere        |
+| cherry-pick | cherry-picken    | Öpfel pflücke   |
+| checkout    | checkouten       | usbueche        |
+| squash      | squashen         | quätsche        |
+
+Da no es paar wiiteri (üsserst ernsti):
+
+| Substantiv    | Jetzige Uusdruck | Vorschlag           |
+| ------------- | ---------------- | ------------------- |
+| git           | git              | Totsch              |
+| github        | github           | Totschzentrum       |
+| gitlab        | gitlab           | Totschlabor         |
+| gitea         | gitea            | Totschtee           |
+| blame         | blame            | Beschuldigung       |
+| bitbucket     | bitbucket        | Gebiss-Chübel       |
+| repository    | repo             | Schopf              |
+| branch        | branch           | Zwiigli             |
+| commit        | commit           | Iihbuechig          |
+| log           | log              | Tagebuech           |
+| pull request  | pull request     | Ziehbegehre         |
+| merge request | merge request    | Ahtrag zum zemmetue |
+| stash         | stash            | Versteck            |
+| status        | status           | Zuestand            |
+| tag           | tag              | Markierig           |
+| origin        | origin           | Ursprung            |
+| master        | master           | Meister             |
+| main          | main             | Haupt               |
+
+## Biispiel
+
+    - Chach du s Zwiigli, wo ich grad gmacht ha, züche und zum Totschzentrum drucke?
+
+    - Für das han ich en neue Schopf gmacht, tue's nahmache und nimm dir s Entwickler-Zwiigli.
+
+    - Nei, druck das grad zum Meister im Ursprung!
+
+    - Du chasch i de Deppe-Beschuldigung gseh, wer das gmacht het.
+
+    - Ich ha grad abboge und d Änderige us mim Versteck übergeh.
+
+    - Mach es Ziehbegehre, wenn du mitem Zemmetue fertig bisch!
+
+    - Am beste pflücked mir d Öpfel usem Hauptzwiigli use.
+
+    - Büüged Sie's ab im Totschzentrum!
+
+    - Wenn'd fertig bisch, chasch's Ziehbegehre sofort quätsche und zemmetue.
+
+    - Im Totsch-Tagebuech chasch nahlese, wer zletzt e quätschti Übergab zemme tue het.
+
+## Totsch uf Thurgauerisch bruuche
+
+Die wo de nächst Schritt mache wönd, chöned die Ahleitig bruche, wo de Totsch uf Thurgauerisch i ihri Konsole bringt. Will de Totsch kei Umluut zuelaht, müend mir i de einzelne Befehl leider druf verzichte. Mach die Änderige i dis `~/.gitconfig` ine:
+
+    git config --global alias.ahfange init
+    git config --global alias.machnah clone
+    git config --global alias.zieh pull
+    git config --global alias.tuedezue add
+    git config --global alias.druck push
+    git config --global alias.pfudle 'push --force'
+    git config --global alias.zwiigli branch
+    git config --global alias.zwiigab branch
+    git config --global alias.buechiih commit
+    git config --global alias.gahufwiifelde rebase
+    git config --global alias.unterscheide diff
+    git config --global alias.tuezemme merge
+    git config --global alias.versorg stash
+    git config --global alias.markier tag
+    git config --global alias.buechuus checkout
+    git config --global alias.tagebuech log
+    git config --global alias.zuestand status
+    git config --global alias.beschuldige blame
+
+Und wenn's die Ziile no i dis `~/.bashrc` (oder wie die Datei au immer heisst uf dim Betriebssystem) tuesch:
+
+    alias totsch='git'
+https://github.com/danielauener/git-auf-deutsch.git

--- a/thurgauerisch.sh
+++ b/thurgauerisch.sh
@@ -1,20 +1,28 @@
 #!/bin/bash
 git config --local alias.ahfange init
-git config --local alias.machnah clone
-git config --local alias.zieh pull
 git config --local alias.tuedezue add
+git config --local alias.beschuldig blame
+git config --local alias.zieh pull
 git config --local alias.druck push
-git config --local alias.pfudle 'push --force'
-git config --local alias.zwiigli branch
+git config --local alias.machnah clone
+git config --local alias.hol fetch
 git config --local alias.zwiigab branch
 git config --local alias.buechiih commit
+git config --local alias.eich rebase
+git config --local alias.erd rebase
 git config --local alias.gahufwiifelde rebase
-git config --local alias.unterscheide diff
+git config --local alias.vergliich diff
 git config --local alias.tuezemme merge
 git config --local alias.versorg stash
 git config --local alias.markier tag
 git config --local alias.pflueckoepfel cherry-pick
+git config --local alias.pflueckhimbeeri cherry-pick
 git config --local alias.buechuus checkout
+git config --local alias.quaetsch 'merge --squash'
+git config --local alias.pfudle 'push --force'
+git config --local alias.beschuldigung blame
+git config --local alias.zwiigli branch
 git config --local alias.tagebuech log
+git config --local alias.versteck stash
 git config --local alias.zuestand status
-git config --local alias.beschuldig blame
+git config --local alias.markierig tag

--- a/thurgauerisch.sh
+++ b/thurgauerisch.sh
@@ -13,6 +13,7 @@ git config --local alias.unterscheide diff
 git config --local alias.tuezemme merge
 git config --local alias.versorg stash
 git config --local alias.markier tag
+git config --local alias.pflueckoepfel cherry-pick
 git config --local alias.buechuus checkout
 git config --local alias.tagebuech log
 git config --local alias.zuestand status

--- a/thurgauerisch.sh
+++ b/thurgauerisch.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+git config --local alias.ahfange init
+git config --local alias.machnah clone
+git config --local alias.zieh pull
+git config --local alias.tuedezue add
+git config --local alias.druck push
+git config --local alias.pfudle 'push --force'
+git config --local alias.zwiigli branch
+git config --local alias.zwiigab branch
+git config --local alias.buechiih commit
+git config --local alias.gahufwiifelde rebase
+git config --local alias.unterscheide diff
+git config --local alias.tuezemme merge
+git config --local alias.versorg stash
+git config --local alias.markier tag
+git config --local alias.buechuus checkout
+git config --local alias.tagebuech log
+git config --local alias.zuestand status
+git config --local alias.beschuldige blame

--- a/thurgauerisch.sh
+++ b/thurgauerisch.sh
@@ -17,4 +17,4 @@ git config --local alias.pflueckoepfel cherry-pick
 git config --local alias.buechuus checkout
 git config --local alias.tagebuech log
 git config --local alias.zuestand status
-git config --local alias.beschuldige blame
+git config --local alias.beschuldig blame


### PR DESCRIPTION
Das Ziehbegehre tuet Dateie in Schopf ine, wo d Nutzig vo Git uf Thurgauerisch erlaubed.
Ich glaube, es wird Ziit, dass au (heftig chliini Teil) vo de Schwiiz i dem Schopf vertrete werded!