### PR TITLE
säggssche fersschion a kleenes biddel runder gemacht

### DIFF
--- a/README-saechsisch.md
+++ b/README-saechsisch.md
@@ -9,7 +9,7 @@ Git off Deudsch (Säggssch) ziehd die Karre ausm Mist!
 
 ## Vorschläsche
 
-Nu folschen zwee Dabelln mit Vorschläschen für den däglichen Gebrauch.
+Nu folschen zwee Dabelln mit Vorschläschen fürn däglichen Gebrauch.
 
 | Verb        | Aktueller Gebrauch | Vorschlach             |
 |-------------|--------------------|------------------------|


### PR DESCRIPTION
"für den" → "fürn"

Hinnergrund:  "für den" hört sisch biddel arg nach Wessi an.