### PR TITLE
Doppeldeutigkeit bei "branch" und "fork" gelöst.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Es folgen zwei Tabellen mit Vorschlägen für den täglichen Gebrauch.
 | rebase      | rebasen            | (neu) erden           |
 | diff        | diffen             | unterscheiden         |
 | merge       | mergen             | zusammenführen        |
-| fork        | forken             | abzweigen             |
+| fork        | forken             | gabeln                |
 | stash       | stashen            | verstauen             |
 | tag         | taggen             | markieren             |
 | cherry-pick | cherry-picken      | Rosinen herauspicken  |


### PR DESCRIPTION
"branch" und "fork" werden beide mit demselben deutschen Wort gelöst: "abzweigen".

Aber "gabeln" ist laut https://synonyme.woxikon.de/synonyme/abzweigen.php ein gültiges Synonym für "abzweigen".
Das wäre somit eindeutig zu unterscheiden, ich würde vorschlagen hier genau dieselben unterschiedlichen Wörter zu verwenden wie im Englischen.